### PR TITLE
fix GREP_OPTIONS deprecation warning

### DIFF
--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -55,7 +55,7 @@ unsetopt CHECK_JOBS       # Don't report on jobs when shell exit.
 
 # Grep
 if zstyle -t ':dotzsh:module:environment:grep' color; then
-  export GREP_OPTIONS='--color=auto'
+  alias grep='grep --color=auto'
 fi
 
 # Set the PAGER

--- a/modules/theme/init.zsh
+++ b/modules/theme/init.zsh
@@ -85,7 +85,7 @@ if zstyle -t ':dotzsh:module:environment:grep' color; then
   elif (( ${#_theme_grepcolors} > 0  )); then
     export GREP_COLOR="$_theme_grepcolors"
   fi
-  export GREP_OPTIONS='--color=auto'
+  alias grep='grep --color=auto'
 fi
 
 if zstyle -t ':dotzsh:module:completion' loaded; then


### PR DESCRIPTION
While this does fix the warning I've seen on login, this can be broken if a user creates their own grep alias, which would override this one. I think it will be good enough for users that just want the default dotzsh behavior.
