### PR TITLE
Fix test for WORKON_HOME

### DIFF
--- a/modules/python/init.zsh
+++ b/modules/python/init.zsh
@@ -25,7 +25,7 @@ else
 fi
 
 # Load virtualenvwrapper into the shell session.
-if [[ -z "$WORKON_HOME" ]] && (( $+commands[virtualenvwrapper_lazy.sh] )); then
+if [[ -n "$WORKON_HOME" ]] && (( $+commands[virtualenvwrapper_lazy.sh] )); then
   source "$commands[virtualenvwrapper_lazy.sh]"
 fi
 


### PR DESCRIPTION
The WORKON_HOME test to load the virtualenvwrapper is checking for an
empty WORKON_HOME. It should be testing that it is not empty.